### PR TITLE
Support minimum characters to complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,12 @@ au User asyncomplete_setup call asyncomplete#register_source(asyncomplete#source
   \ 'name': 'look',
   \ 'whitelist': ['*'],
   \ 'completor': function('asyncomplete#sources#look#completor'),
+  \ 'config': {
+  \   'complete_min_chars': 2,
+  \ },
   \ }))
 ```
+
+If `complete_min_chars` is set, do not show the completion popup until the specified number of characters is reached. (Optional)
+
+If this is not set, `g:asyncomplete_min_chars` will be used.

--- a/autoload/asyncomplete/sources/look.vim
+++ b/autoload/asyncomplete/sources/look.vim
@@ -10,6 +10,7 @@ function! asyncomplete#sources#look#completor(opt, ctx)
   let l:keyword_len = len(l:keyword)
 
   if l:keyword_len < 1
+    call asyncomplete#complete(a:opt['name'], a:ctx, l:startcol, l:matches, 1)
     return
   endif
 

--- a/autoload/asyncomplete/sources/look.vim
+++ b/autoload/asyncomplete/sources/look.vim
@@ -5,11 +5,13 @@ endfunction
 function! asyncomplete#sources#look#completor(opt, ctx)
   let l:col = a:ctx['col']
   let l:typed = a:ctx['typed']
+  let l:config = get(a:opt, 'config', {'complete_min_chars': 2})
+  let l:complete_min_chars = get(l:config, 'complete_min_chars', 2)
 
-  let l:keyword = matchstr(l:typed, '\v[a-z,A-Z]+$')
+  let l:keyword = matchstr(l:typed, '\v[a-z,A-Z]{'.l:complete_min_chars.',}$')
   let l:keyword_len = len(l:keyword)
 
-  if l:keyword_len < 1
+  if l:keyword_len < l:complete_min_chars
     call asyncomplete#complete(a:opt['name'], a:ctx, l:startcol, l:matches, 1)
     return
   endif


### PR DESCRIPTION
The default number of characters for asyncomplete.vim to begin completion is 1, but it will be too heavy if the look command returns too many.

Therefore, it is possible to specify the number of characters to fire completion.
